### PR TITLE
Update rvec_to_matlabcell to handle more types of R vectors/cell arrays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,5 +17,8 @@ License: GPL-2
 Encoding: UTF-8
 SystemRequirements: MATLAB
 BugReports: https://github.com/muschellij2/matlabr/issues
-RoxygenNote: 7.1.0
-Suggests: covr
+RoxygenNote: 7.2.3
+Suggests: 
+    covr,
+    testthat (>= 3.0.0)
+Config/testthat/edition: 3

--- a/R/rvec_to_matlab.R
+++ b/R/rvec_to_matlab.R
@@ -16,10 +16,10 @@ rvec_to_matlabclist = function(x, matname = NULL){
 
 
 
-#' @title Convert R vector to matlab cell mat
+#' @title Convert R vector to matlab vector
 #'
-#' @description This function takes in an R numeric and returns a
-#' status
+#' @description This function takes in an R numeric and turns it into
+#' a Matlab vector
 #' @param x Numeric vector of values
 #' @param row Create row vector instead of column vector
 #' @param sep separator to use to separate cells.  Will override row

--- a/R/rvec_to_matlabcell.R
+++ b/R/rvec_to_matlabcell.R
@@ -2,18 +2,37 @@
 #'
 #' @description This function takes in an R vector then turns it into 
 #' a cell
-#' @param x Character vector of values
-#' @param sep separator to use to separate values. Defaults to ";"
-#' argument 
+#' @param x Vector or list of values.
+#' @param sep separator to use to separate values. Defaults to ";".
+#' If `x` is list, `sep` applies to the inner cell vectors also.
 #' @param matname Object in matlab to be assigned
 #' @param transpose Transpose the cell
 #' @export
-#' @return Character scalar of matlab code
-rvec_to_matlabcell = function(x, 
+#' @return Character scalar of matlab code. If `x` is a list of 
+#' all numeric vectors, returns a matlab cell array of vectors. 
+#' If `x` is a list containing any character vectors, 
+#' returns a matlab nested cell array.
+#' @import stringr
+rvec_to_matlabcell = function(x,
                               sep = ";",
                               matname = NULL, 
                               transpose = FALSE){
-  x = paste0("'", x, "'", sep)
+  if (is.numeric(x)) {
+    # do nothing
+  } else if (is.list(x)) {
+    if (all(sapply(x, is.numeric))) {
+      x = sapply(x, rvec_to_matlab, sep = sep)
+    } else {
+      # Might have unpredicted coercion behavior if there's any other objs in the list
+      stopifnot(sapply(x, is.vector))
+      x = sapply(x, rvec_to_matlabcell, sep = sep)
+    }
+    # trim off the eol semicolon bc these are going into a longer call
+    x = str_sub(x, end = -2L)
+  } else {
+    x = paste0("'", x, "'")
+  }
+  x = paste0(x, sep)
   x = paste(x, collapse = " ")
   x = paste0("{", x, "}", ifelse(transpose, "'", ""), ";")
   if (!is.null(matname)) x = paste0(matname, " = ", x)

--- a/R/rvec_to_matlabcell.R
+++ b/R/rvec_to_matlabcell.R
@@ -15,7 +15,7 @@ rvec_to_matlabcell = function(x,
                               transpose = FALSE){
   x = paste0("'", x, "'", sep)
   x = paste(x, collapse = " ")
-  x = paste0("{", x, "}", ifelse(transpose, "'", ""), sep)
+  x = paste0("{", x, "}", ifelse(transpose, "'", ""), ";")
   if (!is.null(matname)) x = paste0(matname, " = ", x)
   x
 }

--- a/man/rvec_to_matlab.Rd
+++ b/man/rvec_to_matlab.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/rvec_to_matlab.R
 \name{rvec_to_matlab}
 \alias{rvec_to_matlab}
-\title{Convert R vector to matlab cell mat}
+\title{Convert R vector to matlab vector}
 \usage{
 rvec_to_matlab(x, row = FALSE, sep = NULL, matname = NULL)
 }
@@ -20,6 +20,6 @@ argument}
 Character scalar of matlab code
 }
 \description{
-This function takes in an R numeric and returns a
-status
+This function takes in an R numeric and turns it into
+a Matlab vector
 }

--- a/man/rvec_to_matlabcell.Rd
+++ b/man/rvec_to_matlabcell.Rd
@@ -7,17 +7,20 @@
 rvec_to_matlabcell(x, sep = ";", matname = NULL, transpose = FALSE)
 }
 \arguments{
-\item{x}{Character vector of values}
+\item{x}{Vector or list of values.}
 
-\item{sep}{separator to use to separate values. Defaults to ";"
-argument}
+\item{sep}{separator to use to separate values. Defaults to ";".
+If `x` is list, `sep` applies to the inner cell vectors also.}
 
 \item{matname}{Object in matlab to be assigned}
 
 \item{transpose}{Transpose the cell}
 }
 \value{
-Character scalar of matlab code
+Character scalar of matlab code. If `x` is a list of 
+all numeric vectors, returns a matlab cell array of vectors. 
+If `x` is a list containing any character vectors, 
+returns a matlab nested cell array.
 }
 \description{
 This function takes in an R vector then turns it into 

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,0 +1,12 @@
+# This file is part of the standard setup for testthat.
+# It is recommended that you do not modify it.
+#
+# Where should you do additional test configuration?
+# Learn more about the roles of various files in:
+# * https://r-pkgs.org/testing-design.html#sec-tests-files-overview
+# * https://testthat.r-lib.org/articles/special-files.html
+
+library(testthat)
+library(matlabr)
+
+test_check("matlabr")

--- a/tests/testthat/test-test_rvec.R
+++ b/tests/testthat/test-test_rvec.R
@@ -1,0 +1,29 @@
+library(stringr)
+
+test_that("rvec_to_matlabcell behaves the same with default args", {
+  # called with only the x arg specified
+  expect_equal(rvec_to_matlabcell(letters[1:3]), "{'a'; 'b'; 'c';};")
+})
+
+test_that("rvec_to_matlabcell does not quote numeric inputs", {
+  numeric_vector <- 1:3
+  # this should undo the matlab cell array syntax and recover the "numbers" within
+  # without stripping off single quotes applied by rvec_to_matlabcell
+  recovered_vector <- as.numeric(
+    str_split_1(
+      str_remove_all(
+        rvec_to_matlabcell(1:3), 
+        "\\{|\\}|;"),
+      " ")
+  )
+  expect_equal(numeric_vector, recovered_vector)
+})
+
+test_that("rvec_to_matlabcell always closes the line with semicolon", {
+  expect_true(endsWith(rvec_to_matlabcell(letters[1:3]), ";"))
+  expect_true(endsWith(rvec_to_matlabcell(letters[1:3], sep = ","), ";"))
+})
+
+test_that("rvec_to_matlabcell errors when list contains non-vectors", {
+  expect_error(rvec_to_matlabcell(list(mean)))
+})


### PR DESCRIPTION
Closes #5 .

Fixed:
- Some of the roxygen documentation for a couple functions, didn't seem to match what the functions were actually doing--seemed like copy-paste typos
- `rvec_to_matlabcell()` now hard-coded to append the semicolon as the end-of-line character. Was previously using the value of the `sep` argument (unlike any of the other functions), which was thus appending a comma as the end-of-line character when `sep = ","`

Added:
- `rvec_to_matlabcell()` only quotes cell values when the input vector is not numeric
- `rvec_to_matlabcell()` now accepts lists of numeric vectors, and uses `rvec_to_matlab()` to turn each list element into a Matlab vector in one element of a cell array
- `rvec_to_matlabcell()` now accepts lists of character vectors, and uses `rvec_to_matlabcell()` recursively to turn each list element into a sub-cell-array in one element of a cell array
- `testthat` tests for said new features, and to check that existing function calls using default args will not change

I tried to update as few packages/add as few dependencies as possible. The only major dependency addition is that `testthat` is now suggested, and that I used a newer version of `roxygen2` to update those docs per above.