### PR TITLE
paths should be added before the code

### DIFF
--- a/R/matlab_script.R
+++ b/R/matlab_script.R
@@ -201,7 +201,7 @@ run_matlab_code = function(
            paste0("cd('", getwd(), "');"), code)
   if (!is.null(paths_to_add)) {
     paths_to_add = add_path(paths_to_add)
-    code = c(code, paths_to_add)
+    code = c(paths_to_add, code)
   }
   sep = ifelse(endlines, ";", " ")
   code = paste0(code, sep = sep, collapse = "\n")


### PR DESCRIPTION
When I run `matlabr::run_matlab_code()`  and provide `paths_to_add`, they are added *after* my code, which is unfortunate. It should be the other way round.